### PR TITLE
troubleshooting: creating EC2 Subnet: InvalidParameterValue: Value (u…

### DIFF
--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -5,7 +5,7 @@ resource "aws_vpc" "my_vpc" {
 resource "aws_subnet" "subnet_a" {
   vpc_id     = aws_vpc.my_vpc.id
   cidr_block = "10.0.1.0/24"
-  availability_zone = "us-east-1"
+  availability_zone = "us-east-1a"
 }
 
 resource "aws_subnet" "subnet_b" {


### PR DESCRIPTION
…s-east-1) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1e, us-east-1f.